### PR TITLE
feat: v0.1.2 - AI instruction injection in init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2024-09-06
+
+### Added
+
+- `loomtype init` now automatically adds verification instructions to AI assistant files
+- Auto-detection of AI files (CLAUDE.md, AGENTS.md, .cursorrules, .github/copilot-instructions.md)
+- Creates AGENTS.md if no AI files exist
+- Idempotent operation - safe to run init multiple times
+
+### Changed
+
+- Combined config creation and AI instructions into single `init` command
+- Simplified workflow from 3 steps to 2
+
 ## [0.1.1] - 2024-09-06
 
 ### Added
@@ -46,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration tests using Jest
 - GitHub Actions CI for multiple Node versions
 
-[Unreleased]: https://github.com/rivendare/loomtype/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/rivendare/loomtype/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/rivendare/loomtype/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/rivendare/loomtype/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/rivendare/loomtype/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -84,28 +84,24 @@ npm install -g loomtype
 ## Quick Start
 
 ```bash
-# create .loomtype.yaml with your patterns
+# 1. creates .loomtype.yaml template + adds instructions to AI files
 loomtype init
 
-# verify AI implemented them correctly
+# 2. edit .loomtype.yaml with your patterns and verification checks
+
+# 3. AI runs this (you can too) - keep running until all checks pass
 loomtype verify
 ```
 
 ## How to Use with AI
 
-Give your AI this prompt:
+When you run `loomtype init`, it:
+1. Creates a `.loomtype.yaml` template for you to fill in
+2. Automatically adds instructions to your AI assistant files (CLAUDE.md, .cursorrules, etc.)
 
-```
-This project uses loomtype for pattern verification. Please:
+The AI will see instructions to run `loomtype verify` after making code changes and continue fixing issues until all checks pass.
 
-1. Read the .loomtype.yaml file to understand required patterns
-2. Implement all patterns described
-3. After each major change, run `loomtype verify` 
-4. If any checks fail, read the on_fail hints and fix them
-5. Continue until all checks pass
-
-Important: Keep running `loomtype verify` as you work to ensure patterns are properly implemented!
-```
+> **Note:** You may need to remind the AI to run `loomtype verify` after changes - it's a good practice to mention it when giving implementation tasks.
 
 ## Examples
 
@@ -117,7 +113,7 @@ Check out the [examples directory](./examples) for real-world `.loomtype.yaml` f
 ## Commands
 
 ```bash
-loomtype init           # create .loomtype.yaml
+loomtype init           # create config + AI instructions
 loomtype verify         # check patterns exist
 loomtype help           # show help
 loomtype version        # show version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loomtype",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Verify AI implemented your requirements",
   "author": "rivendare",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- `loomtype init` now automatically adds verification instructions to AI assistant files
- Auto-detects existing AI files (CLAUDE.md, AGENTS.md, .cursorrules, .github/copilot-instructions.md)
- Creates AGENTS.md with instructions if no AI files exist

Closes #2

## Changes
- Modified `init` command to always call `addAIInstructions()` method
- Added idempotent AI instruction injection with LOOMTYPE BLOCK markers
- Added 6 new integration tests for comprehensive coverage (20 tests total)
- Updated README for clarity on the init workflow
- Bumped version to 0.1.2

## Test plan
- [x] All existing tests pass
- [x] New tests cover all permutations of AI file scenarios
- [x] Manual testing of init command with various file configurations
- [x] Lint and format checks pass